### PR TITLE
fix(typo): fix inconsistent svc type in default values.yaml

### DIFF
--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -115,7 +115,7 @@ service:
   enabled: true
   labels: {}
   annotations: {}
-  serviceType: ClusterIP
+  type: ClusterIP
 
 
 route:


### PR DESCRIPTION
according to the configuration values table, the type of a service field name should be `type` instead of `serviceType`